### PR TITLE
Hook WaitForCommunicator instead of Boot

### DIFF
--- a/lib/vagrant-notify/plugin.rb
+++ b/lib/vagrant-notify/plugin.rb
@@ -13,7 +13,7 @@ module Vagrant
       #       possible provider action class that Vagrant might have
       start_server_hook = lambda do |hook|
         require_relative './action'
-        hook.after VagrantPlugins::ProviderVirtualBox::Action::Boot, Vagrant::Notify::Action.action_start_server
+        hook.after VagrantPlugins::ProviderVirtualBox::Action::WaitForCommunicator, Vagrant::Notify::Action.action_start_server
 
         if defined?(Vagrant::LXC)
           require 'vagrant-lxc/action'


### PR DESCRIPTION
If you are hooking Boot, this will fail on first boot trying to send the plugin with communicator. Instead hook WaitForCommunicator, then we know we send the plugin.