### PR TITLE
Make notify-send working even without ssh connection

### DIFF
--- a/files/notify-send.erb
+++ b/files/notify-send.erb
@@ -12,7 +12,7 @@ require 'fileutils'
 
 options = {}
 OptionParser.new do |opts|
-  opts.banner = "Usage: example.rb [options]"
+  opts.banner = "Usage: notify-send.rb [options]"
 
   opts.on('-u', '--urgency LEVEL')           { |v| options[:u] = v }
   opts.on('-t', '--expire-time TIME')        { |v| options[:t] = v }
@@ -40,7 +40,7 @@ unless ARGV.empty?
   cmd << ARGV.map{|a| "'#{a}'"}.join(' ')
 end
 
-client_ip = ENV['SSH_CLIENT'].split(' ')[0]
-TCPSocket.open ENV['SSH_CLIENT'], <%= host_port %> do |s|
+client_ip = `netstat -rn | grep "^0.0.0.0 " | cut -d " " -f10`
+TCPSocket.open client_ip, <%= host_port %> do |s|
   s.send cmd, 0
 end


### PR DESCRIPTION
Because of `ENV['SSH_CLIENT']` is used to retrieve the host IP, it is now possible to use the script only inside the SSH connection to Vagrant box (= only in child processes of your `vagrant ssh` terminal). However this is limiting when the notify-send is called by some other (background) command run in the vagrant (and thus it doesn't have the environment variable set).

This change is based on https://stackoverflow.com/questions/19917148/tell-vagrant-the-ip-of-the-host-machine and removes the dependency on this environment variable, as it is retrieving the host IP dynamically from `netstat` output.