### PR TITLE
config options for notification app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ test/version_tmp
 tmp
 /development/.vagrant
 .DS_Store
+.idea/

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ end
 ```
 
 By default local server uses ***notify_send*** command for displaying notifications, there is a possibility to use different app without wrapper scripts: 
-* ***notify.sender\_app*** configuration option is used for specifing application name
-* ***notify.sender\_params\_str*** defines how params for applications will be passed. You can use these variables (escaped by `{` and `}` characters) here:
+* ***notify.sender\_app*** configuration option is used for specifing application name (default: `notify-send`)
+* ***notify.sender\_params\_str*** defines how params for applications will be passed (default: `[--app-name {app_name}] [--urgency {urgency}] [--expire-time {expire_time}] [--icon {icon}] [--category {category}] [--hint {hint}] {message}`). You can use these variables (escaped by `{` and `}` characters) here:
   * ***urgency*** - urgency level for notification
   * ***expire\_time*** - when notification will expire?
   * ***app\_name*** - application name
@@ -81,7 +81,7 @@ By default local server uses ***notify_send*** command for displaying notificati
   * ***category*** - category for the notification (can be multiple, devided by comma)
   * ***hint*** - icon for the notification (need to use this format: TYPE:NAME:VALUE)
   * ***message*** - message to send
-* ***notify.sender\_params\_escape*** - should params will be escaped when passed to script (default: true)
+* ***notify.sender\_params\_escape*** - should params will be escaped when passed to script (default: `true`)
 
 This is example how to to run notifications with build-in MacOS X notifications support:
 ```ruby

--- a/README.md
+++ b/README.md
@@ -71,8 +71,19 @@ Vagrant.configure(2) do |config|
 end
 ```
 
-By default local server uses ***notify_send*** command for displaying notifications, there is a possibility to use different app without wrapper scripts. ***notify.sender\_app*** configuration option is used for specifing application name. ***notify.sender_params_str*** defines
+By default local server uses ***notify_send*** command for displaying notifications, there is a possibility to use different app without wrapper scripts: 
+* ***notify.sender\_app*** configuration option is used for specifing application name
+* ***notify.sender\_params\_str*** defines how params for applications will be passed. You can use these variables (escaped by `{` and `}` characters) here:
+  * ***urgency*** - urgency level for notification
+  * ***expire\_time*** - when notification will expire?
+  * ***app\_name*** - application name
+  * ***icon*** - icon for the notification (can be multiple, devided by comma)
+  * ***category*** - category for the notification (can be multiple, devided by comma)
+  * ***hint*** - icon for the notification (need to use this format: TYPE:NAME:VALUE)
+  * ***message*** - message to send
+* ***notify.sender\_params\_escape*** - should params will be escaped when passed to script (default: true)
 
+This is example how to to run notifications with build-in MacOS X notifications support:
 ```ruby
 Vagrant.configure(2) do |config|
   config.vm.box = "ubuntu/trusty64"

--- a/README.md
+++ b/README.md
@@ -71,6 +71,17 @@ Vagrant.configure(2) do |config|
 end
 ```
 
+By default local server uses ***notify_send*** command for displaying notifications, there is a possibility to use different app without wrapper scripts. ***notify.sender\_app*** configuration option is used for specifing application name. ***notify.sender_params_str*** defines
+
+```ruby
+Vagrant.configure(2) do |config|
+  config.vm.box = "ubuntu/trusty64"
+  config.notify.sender_params_str = '-e \'display notification {message} sound name \"default\"\''
+  config.notify.sender_app = 'osascript'
+  config.notify.sender_params_escape = true
+end
+```
+
 **WARNING**
 
 _Do **NOT** bind the notification server to an IP accessible over a network! The notification server does not have any authentication and doing so will leave your system vulnerable to remote command execution._

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,9 +1,0 @@
-Vagrant.configure("2") do |config|
-  config.vm.box = "ubuntu/trusty64"
-  config.vm.synced_folder "../", "/vagrant", id: 'vagrant-root'
-
-  config.notify.enable = true
-  config.notify.sender_params_str = '-e \'display notification {message} sound name \"default\"\''
-  config.notify.sender_app = 'osascript'
-  config.notify.sender_params_escape = true
-end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,9 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/trusty64"
+  config.vm.synced_folder "../", "/vagrant", id: 'vagrant-root'
+
+  config.notify.enable = true
+  config.notify.sender_params_str = '-e \'display notification {message} sound name \"default\"\''
+  config.notify.sender_app = 'osascript'
+  config.notify.sender_params_escape = true
+end

--- a/files/notify-send.erb
+++ b/files/notify-send.erb
@@ -8,18 +8,19 @@ require 'rubygems'
 require 'socket'
 require 'optparse'
 require 'fileutils'
+require 'json'
 
 options = {}
 OptionParser.new do |opts|
   opts.banner = "Usage: notify-send.rb [options]"
 
-  opts.on('-u', '--urgency LEVEL')           { |v| options[:u] = v }
-  opts.on('-t', '--expire-time TIME')        { |v| options[:t] = v }
-  opts.on('-a', '--app-name APP_NAME')       { |v| options[:a] = v }
-  opts.on('-i', '--icon ICON[,ICON...]')     { |v| options[:i] = v }
-  opts.on('-c', '--category TYPE[,TYPE...]') { |v| options[:c] = v }
-  opts.on('-h', '--hint TYPE:NAME:VALUE')    { |v| options[:h] = v }
-  opts.on('-v', '--version')                 { |v| options[:v] = v }
+  opts.on('-u', '--urgency LEVEL')           { |v| options[:urgency] = v }
+  opts.on('-t', '--expire-time TIME')        { |v| options[:expire_time] = v }
+  opts.on('-a', '--app-name APP_NAME')       { |v| options[:app_name] = v }
+  opts.on('-i', '--icon ICON[,ICON...]')     { |v| options[:icon] = v }
+  opts.on('-c', '--category TYPE[,TYPE...]') { |v| options[:category] = v }
+  opts.on('-h', '--hint TYPE:NAME:VALUE')    { |v| options[:hint] = v }
+  opts.on('-v', '--version')                 { |v| options[:version] = v }
 
 end.parse!
 
@@ -32,15 +33,7 @@ unless RUBY_PLATFORM =~ /freebsd|openbsd|netbsd/
   end
 end
 
-cmd = options.map do |key, value|
-  "-#{key} '#{value}'"
-end.join(' ')
-
-# All single quotes part of the message get removed.
-# TODO: Need to escape values.
-unless ARGV.empty?
-  cmd << ARGV.map{|a| " '#{a.gsub(/'/, "")}'"}.join(' ')
-end
+cmd = JSON.generate(options, quirks_mode: true)
 
 # VirtualBox is the only provider that can communicate with 127.0.0.1, others will have to use default private networking
 if "<%= provider_name %>" == "virtualbox"

--- a/files/notify-send.erb
+++ b/files/notify-send.erb
@@ -24,12 +24,14 @@ OptionParser.new do |opts|
 
 end.parse!
 
+options[:message]=ARGV.pop
+
 # BSD guests do not support shared folders
 unless RUBY_PLATFORM =~ /freebsd|openbsd|netbsd/
-  if options[:i]
-    new_filename = options[:i].gsub('/', '-')
-    FileUtils.cp options[:i], "<%= shared_folder %>/#{new_filename}"
-    options[:i]  = new_filename
+if options[:icon]
+new_filename = options[:icon].gsub('/', '-')
+FileUtils.cp options[:icon], "<%= shared_folder %>/#{new_filename}"
+options[:icon]  = new_filename
   end
 end
 

--- a/files/notify-send.erb
+++ b/files/notify-send.erb
@@ -12,7 +12,7 @@ require 'json'
 
 options = {}
 OptionParser.new do |opts|
-  opts.banner = "Usage: notify-send.rb [options]"
+opts.banner = "Usage: notify-send.rb TITLE [MESSAGE] [options]"
 
   opts.on('-u', '--urgency LEVEL')           { |v| options[:urgency] = v }
   opts.on('-t', '--expire-time TIME')        { |v| options[:expire_time] = v }
@@ -21,10 +21,10 @@ OptionParser.new do |opts|
   opts.on('-c', '--category TYPE[,TYPE...]') { |v| options[:category] = v }
   opts.on('-h', '--hint TYPE:NAME:VALUE')    { |v| options[:hint] = v }
   opts.on('-v', '--version')                 { |v| options[:version] = v }
-
 end.parse!
 
-options[:message]=ARGV.pop
+options[:title]=ARGV.pop
+options[:message]=ARGV.pop if ARGV.length > 0
 
 # BSD guests do not support shared folders
 unless RUBY_PLATFORM =~ /freebsd|openbsd|netbsd/
@@ -47,7 +47,6 @@ if "<%= provider_name %>" == "virtualbox"
 else
   client_ip = "<%= client_ip %>"
 end
-
 
 TCPSocket.open client_ip, <%= host_port %> do |s|
   s.send cmd, 0

--- a/lib/vagrant-notify/action/start_server.rb
+++ b/lib/vagrant-notify/action/start_server.rb
@@ -23,11 +23,12 @@ module Vagrant
           bind_ip=env[:notify_data][:bind_ip]
 
           port = next_available_port(bind_ip)
-          sender_app = '"' + Shellwords.escape(env[:machine].provider_name) + '"'
-          sender_params_str = '"' + Shellwords.escape(env[:machine].sender_params_str) + '"'
+          sender_app = '"' + env[:machine].config.notify.sender_app + '"'
+          sender_params_str = '"' + env[:machine].config.notify.sender_params_str + '"'
+          sender_params_escape = (env[:machine].config.notify.sender_params_escape) ? 1 : 0
 
           if which('ruby')
-            env[:notify_data][:pid] = Process.spawn("ruby #{dir}/server.rb #{id} #{port} #{bind_ip} #{provider_name} #{sender_app} #{sender_params_str}")
+            env[:notify_data][:pid] = Process.spawn("ruby #{dir}/server.rb #{id} #{port} #{bind_ip} #{sender_app} #{sender_params_str} #{sender_params_escape} #{provider_name}")
             env[:notify_data][:port] = port
 
             sleep 5

--- a/lib/vagrant-notify/action/start_server.rb
+++ b/lib/vagrant-notify/action/start_server.rb
@@ -20,10 +20,14 @@ module Vagrant
           
           return if env[:machine].config.notify.enable == false
 
-          port = next_available_port(env[:notify_data][:bind_ip])
+          bind_ip=env[:notify_data][:bind_ip]
+
+          port = next_available_port(bind_ip)
+          sender_app = '"' + Shellwords.escape(env[:machine].provider_name) + '"'
+          sender_params_str = '"' + Shellwords.escape(env[:machine].sender_params_str) + '"'
 
           if which('ruby')
-            env[:notify_data][:pid]  = Process.spawn("ruby #{dir}/server.rb #{id} #{port} #{env[:notify_data][:bind_ip]} #{provider_name}")
+            env[:notify_data][:pid] = Process.spawn("ruby #{dir}/server.rb #{id} #{port} #{bind_ip} #{provider_name} #{sender_app} #{sender_params_str}")
             env[:notify_data][:port] = port
 
             sleep 5

--- a/lib/vagrant-notify/config.rb
+++ b/lib/vagrant-notify/config.rb
@@ -14,10 +14,14 @@ module Vagrant
       # Notify send params string
       attr_accessor :sender_params_str
 
+      # Sender params escape
+      attr_accessor :sender_params_escape
+
       def initialize()
         @enable  = UNSET_VALUE
         @sender_app = UNSET_VALUE
         @sender_params_str = UNSET_VALUE
+        @sender_params_escape = UNSET_VALUE
       end
 
       def validate(machine)
@@ -31,8 +35,12 @@ module Vagrant
 
         if @enable != 0
           if @enable != false && @enable != true
-            errors << "Unknown option: #{@enable}"
+            errors << "Unknown option for enable: #{@enable}"
           end
+        end
+
+        if @sender_params_escape != false && @sender_params_escape != true && @sender_params_escape != UNSET_VALUE
+          errors << "Unknown option for @sender_params_escape: #{@sender_params_escape}"
         end
 
         if backed_by_supported_provider?(machine)
@@ -57,8 +65,9 @@ module Vagrant
 
       def finalize!
         @enable = 0 if @enable == UNSET_VALUE
-        @sender_app = "notify-send" if @sender_app = UNSET_VALUE
+        @sender_app = "notify-send" if @sender_app == UNSET_VALUE
         @sender_params_str = "[--app-name {app_name}] [--urgency {urgency}] [--expire-time {expire_time}] [--icon {icon}] [--category {category}] [--hint {hint}] {message}" if @sender_params_str == UNSET_VALUE
+        @sender_params_escape = true if @sender_app == UNSET_VALUE
       end
 
       private

--- a/lib/vagrant-notify/config.rb
+++ b/lib/vagrant-notify/config.rb
@@ -66,7 +66,7 @@ module Vagrant
       def finalize!
         @enable = 0 if @enable == UNSET_VALUE
         @sender_app = "notify-send" if @sender_app == UNSET_VALUE
-        @sender_params_str = "[--app-name {app_name}] [--urgency {urgency}] [--expire-time {expire_time}] [--icon {icon}] [--category {category}] [--hint {hint}] {message}" if @sender_params_str == UNSET_VALUE
+        @sender_params_str = "[--app-name {app_name}] [--urgency {urgency}] [--expire-time {expire_time}] [--icon {icon}] [--category {category}] [--hint {hint}] {title} [{message}]" if @sender_params_str == UNSET_VALUE
         @sender_params_escape = true if @sender_app == UNSET_VALUE
       end
 

--- a/lib/vagrant-notify/config.rb
+++ b/lib/vagrant-notify/config.rb
@@ -1,10 +1,23 @@
 module Vagrant
   module Notify
     class Config < Vagrant.plugin(2, :config)
-      attr_accessor :enable, :bind_ip
+
+      # Enable?
+      attr_accessor :enable
+
+      # Bind IP
+      attr_accessor :bind_ip
+
+      # Notify send application
+      attr_accessor :sender_app
+
+      # Notify send params string
+      attr_accessor :sender_params_str
 
       def initialize()
         @enable  = UNSET_VALUE
+        @sender_app = UNSET_VALUE
+        @sender_params_str = UNSET_VALUE
       end
 
       def validate(machine)
@@ -44,6 +57,8 @@ module Vagrant
 
       def finalize!
         @enable = 0 if @enable == UNSET_VALUE
+        @sender_app = "notify-send" if @sender_app = UNSET_VALUE
+        @sender_params_str = "[--app-name {app_name}] [--urgency {urgency}] [--expire-time {expire_time}] [--icon {icon}] [--category {category}] [--hint {hint}] {message}" if @sender_params_str == UNSET_VALUE
       end
 
       private

--- a/lib/vagrant-notify/server.rb
+++ b/lib/vagrant-notify/server.rb
@@ -7,9 +7,11 @@ module Vagrant
       HTTP_RESPONSE = "Hi! You just reached the vagrant notification server"
 
       def self.run(id, port, bind_ip, sender_app, sender_params_str, machine_name='default', provider='virtualbox')
-        #id           = env[:machine].id
-        #machine_name = env[:machine].name
-        #provider     = env[:machine].provider_name
+        #id                   = env[:machine].id
+        #machine_name         = env[:machine].name
+        #provider             = env[:machine].provider_name
+        #sender_app           = env[:machine].sender_app
+        #sender_params_str    = env[:machine].sender_params_str
 
         if __FILE__ == $0
           begin
@@ -38,7 +40,7 @@ module Vagrant
         @id           = id
         @machine_name = machine_name
         @provider     = provider
-        @sender_app  = sender_app
+        @sender_app = Shellwords.escape(sender_app)
         @sender_params = sender_params_str
       end
 
@@ -47,7 +49,7 @@ module Vagrant
         if http_request?(args)
           client.puts HTTP_RESPONSE
         else
-          parsed_args=map_params_str(@sender_params, JSON.parse(args))
+          parsed_args=Shellwords.escape(map_params_str(@sender_params, JSON.parse(args)))
           fix_icon_path! parsed_args
           system "#{@sender_app} #{parsed_args}"
         end

--- a/lib/vagrant-notify/server.rb
+++ b/lib/vagrant-notify/server.rb
@@ -1,17 +1,19 @@
 require 'socket'
 require 'json'
+require 'tmpdir'
 
 module Vagrant
   module Notify
     class Server
       HTTP_RESPONSE = "Hi! You just reached the vagrant notification server"
 
-      def self.run(id, port, bind_ip, sender_app, sender_params_str, machine_name='default', provider='virtualbox')
+      def self.run(id, port, bind_ip, sender_app, sender_params_str, sender_params_escape, machine_name='default', provider='virtualbox')
         #id                   = env[:machine].id
         #machine_name         = env[:machine].name
         #provider             = env[:machine].provider_name
-        #sender_app           = env[:machine].sender_app
-        #sender_params_str    = env[:machine].sender_params_str
+        #sender_app           = env[:machine].config.sender_app
+        #sender_params_str    = env[:machine].config.sender_params_str
+        #sender_params_escape = env[:machine].config.sender_params_escape
 
         if __FILE__ == $0
           begin
@@ -19,7 +21,7 @@ module Vagrant
           rescue
               exit 1
           end
-          server = self.new(id, sender_app, sender_params_str, machine_name, provider)
+          server = self.new(id, sender_app, sender_params_str, sender_params_escape, machine_name, provider)
 
           # Have to wrap this in a begin/rescue block so we can be certain the server is running at all times.
           begin
@@ -36,12 +38,13 @@ module Vagrant
         end
       end
 
-      def initialize(id, sender_app, sender_params_str, machine_name = :default, provider = :virtualbox)
+      def initialize(id, sender_app, sender_params_str, sender_params_escape, machine_name = :default, provider = :virtualbox)
         @id           = id
         @machine_name = machine_name
         @provider     = provider
-        @sender_app = Shellwords.escape(sender_app)
-        @sender_params = sender_params_str
+        @sender_app = sender_app
+        @sender_params_str = sender_params_str
+        @sender_params_escape = sender_params_escape
       end
 
       def receive_data(client)
@@ -49,7 +52,8 @@ module Vagrant
         if http_request?(args)
           client.puts HTTP_RESPONSE
         else
-          parsed_args=Shellwords.escape(map_params_str(@sender_params, JSON.parse(args)))
+          json_data=JSON.parse(args)
+          parsed_args=map_params_str(json_data)
           fix_icon_path! parsed_args
           system "#{@sender_app} #{parsed_args}"
         end
@@ -62,19 +66,18 @@ module Vagrant
 
       # Maps params str with values
       #
-      #@param params_str  [String]  Params string from config
       #@param data        [Map]     Array values map
       #
       #@return [String]
-      def map_params_str(params_str, data)
-        cmd=params_str
+      def map_params_str(data)
+        cmd=@sender_params_str + ''
         cmd.gsub! '%', '%%'
 
         replace=[]
         cmd.scan(/\[[^\]]+\]/).each do |part|
           variable=part[/\{[^\}]+\}/][1..-2]
           if data.key? variable
-            replace << part[1..-2].sub('{' + variable + '}', data[variable])
+            replace << part[1..-2].sub('{' + variable + '}', escape_param(data[variable]))
             cmd.sub! part, '%'+replace.length.to_s+'$s'
           else
             cmd.sub! part, ''
@@ -84,7 +87,7 @@ module Vagrant
         cmd.scan(/\{[^\}]+\}/).each do |part|
           variable=part[1..-2]
           if data.key? variable
-            replace << data[variable]
+            replace << escape_param(data[variable])
             cmd.sub! part, '%'+replace.length.to_s+'$s'
           end
         end
@@ -92,9 +95,26 @@ module Vagrant
       end
 
       def log(message)
-        File.open("/tmp/vagrant-notify-error-#{@id}.log", 'a+') do |log|
+        File.open(@log_path, 'a+') do |log|
           log.puts "#{message}"
         end
+      end
+
+      # Escapes param
+      #
+      #@param param [String] Param
+      #
+      #@return [String]
+      def escape_param(param)
+        return param unless @sender_params_escape
+        '"' + param.gsub('"', "\\\"").gsub("'", "\\'").gsub("\\", "\\\\") + '"'
+      end
+
+      # Gets log path
+      #
+      #@return [String]
+      def log_path
+        File.join Dir.tmpdir(), "vagrant-notify-error-#{@id}.log"
       end
 
       def read_args(client)
@@ -127,5 +147,6 @@ port = ARGV[1]
 bind_ip = ARGV[2]
 sender_app = ARGV[3]
 sender_params_str = ARGV[4]
+sender_params_escape = ARGV[5]
 
-Vagrant::Notify::Server.run id, port, bind_ip, sender_app, sender_params_str
+Vagrant::Notify::Server.run id, port, bind_ip, sender_app, sender_params_str, sender_params_escape

--- a/lib/vagrant-notify/server.rb
+++ b/lib/vagrant-notify/server.rb
@@ -1,11 +1,12 @@
 require 'socket'
+require 'json'
 
 module Vagrant
   module Notify
     class Server
       HTTP_RESPONSE = "Hi! You just reached the vagrant notification server"
 
-      def self.run(id, port, bind_ip, machine_name='default', provider='virtualbox')
+      def self.run(id, port, bind_ip, sender_app, sender_params_str, machine_name='default', provider='virtualbox')
         #id           = env[:machine].id
         #machine_name = env[:machine].name
         #provider     = env[:machine].provider_name
@@ -16,7 +17,7 @@ module Vagrant
           rescue
               exit 1
           end
-          server = self.new(id, machine_name, provider)
+          server = self.new(id, sender_app, sender_params_str, machine_name, provider)
 
           # Have to wrap this in a begin/rescue block so we can be certain the server is running at all times.
           begin
@@ -33,10 +34,12 @@ module Vagrant
         end
       end
 
-      def initialize(id, machine_name = :default, provider = :virtualbox)
+      def initialize(id, sender_app, sender_params_str, machine_name = :default, provider = :virtualbox)
         @id           = id
         @machine_name = machine_name
         @provider     = provider
+        @sender_app  = sender_app
+        @sender_params = sender_params_str
       end
 
       def receive_data(client)
@@ -44,8 +47,9 @@ module Vagrant
         if http_request?(args)
           client.puts HTTP_RESPONSE
         else
-          fix_icon_path!(args)
-          system("notify-send #{args}")
+          parsed_args=map_params_str(@sender_params, JSON.parse(args))
+          fix_icon_path! parsed_args
+          system "#{@sender_app} #{parsed_args}"
         end
         client.close
       rescue => ex
@@ -53,6 +57,37 @@ module Vagrant
       end
 
       private
+
+      # Maps params str with values
+      #
+      #@param params_str  [String]  Params string from config
+      #@param data        [Map]     Array values map
+      #
+      #@return [String]
+      def map_params_str(params_str, data)
+        cmd=params_str
+        cmd.gsub! '%', '%%'
+
+        replace=[]
+        cmd.scan(/\[[^\]]+\]/).each do |part|
+          variable=part[/\{[^\}]+\}/][1..-2]
+          if data.key? variable
+            replace << part[1..-2].sub('{' + variable + '}', data[variable])
+            cmd.sub! part, '%'+replace.length.to_s+'$s'
+          else
+            cmd.sub! part, ''
+          end
+        end
+
+        cmd.scan(/\{[^\}]+\}/).each do |part|
+          variable=part[1..-2]
+          if data.key? variable
+            replace << data[variable]
+            cmd.sub! part, '%'+replace.length.to_s+'$s'
+          end
+        end
+        cmd % replace
+      end
 
       def log(message)
         File.open("/tmp/vagrant-notify-error-#{@id}.log", 'a+') do |log|
@@ -88,5 +123,7 @@ end
 id = ARGV[0]
 port = ARGV[1]
 bind_ip = ARGV[2]
+sender_app = ARGV[3]
+sender_params_str = ARGV[4]
 
-Vagrant::Notify::Server.run(id, port, bind_ip)
+Vagrant::Notify::Server.run id, port, bind_ip, sender_app, sender_params_str


### PR DESCRIPTION
I think it's easier would be not to write wrappers for notify-send app but to define them in Vagrantfile. So, I added few configuration options for plugin:
* sender_app - application name that sends notification
* sender_params_str - string that used to parse parameters for that application when sending notification
* sender_params_escape - do we need to escape all params?

If these parameters are not used, everything I think should work in old way.

I don't know ruby very well so, if there is something bad with my code, let me know. I'll try to improve.