### PR TITLE
avoid error `newline at the end of hostname (SocketError)`

### DIFF
--- a/files/notify-send.erb
+++ b/files/notify-send.erb
@@ -48,6 +48,6 @@ else
   client_ip = "<%= client_ip %>"
 end
 
-TCPSocket.open client_ip, <%= host_port %> do |s|
+TCPSocket.open client_ip.strip, <%= host_port %> do |s|
   s.send cmd, 0
 end


### PR DESCRIPTION
Adding a `strip` after the client_ip avoids the error `newline at the end of hostname (SocketError)` which otherwise prevents the Ruby notify-send.rb from working under Linux when the virtualbox provider is being used.

The other alternative is to change the awk command (for linux at least) to use `printf` instead of `print` to avoid the newline character like this:

```ruby
client_ip = `ip route|awk '/default/ {printf $3}'`
```

I wasn't sure how awk behaved on other RUBY_PLATFORMs so chose the `strip` approach which ought to be fine in all cases including the case where the client_ip is set incorrectly in the Vagrantfile.